### PR TITLE
Add minimum version to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ as well as anything that requires non-const function calls to be computed.
 [![Documentation](https://docs.rs/lazy_static/badge.svg)](https://docs.rs/lazy_static)
 [![License](https://img.shields.io/crates/l/lazy_static.svg)](https://github.com/rust-lang-nursery/lazy-static.rs#license)
 
+## Minimum supported `rustc`
+
+`1.21.0+`
+
+This version is explicitly tested in CI and may only be bumped in new minor versions. Any changes to the supported minimum version will be called out in the release notes.
+
 
 # Getting Started
 


### PR DESCRIPTION
Closes #114

There was a bit of miscommunication in our `1.1.0` release where we broke users who were depending on `lazy_static` on compilers older than the one we were explicitly testing against. This PR adds a note to the readme about what our minimum supported version is and how we change it.

The minimum version is based on the version we explicitly test in CI, which is currently 1.21.0. It also outlines a policy for bumping the minimum version in minor releases if we need to. I think it's fair to say that we try hard not to bump that version unnecessarily, but I didn't want to get too defensive about it in the readme.

cc @jethrogb @BurntSushi